### PR TITLE
Added asterisks to match Javadoc-Style and fix apidoc build script

### DIFF
--- a/server/src/Services/ApiDocs/ApiDocs.php
+++ b/server/src/Services/ApiDocs/ApiDocs.php
@@ -2,12 +2,12 @@
 
 //====[ FOR API DOC JS ]====\\
 
-/**
+/*********************************************************************************
  * @apiDefine Headers_Normal
  * @apiHeader Accept application/json
  */
 
-/**
+/*********************************************************************************
  * @apiDefine Headers_Authenticated
  * @apiHeader Accept application/json
  * @apiHeader Authorization Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ91QiLCJhbGciOiJIUzI1NiJ1...

--- a/server/src/Services/ApiDocs/ApiDocs.php
+++ b/server/src/Services/ApiDocs/ApiDocs.php
@@ -2,12 +2,12 @@
 
 //====[ FOR API DOC JS ]====\\
 
-/*
+/**
  * @apiDefine Headers_Normal
  * @apiHeader Accept application/json
  */
 
-/*
+/**
  * @apiDefine Headers_Authenticated
  * @apiHeader Accept application/json
  * @apiHeader Authorization Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ91QiLCJhbGciOiJIUzI1NiJ1...


### PR DESCRIPTION
Fixed the build script `apidoc -f .php -i src -o public/documentation`

which was giving the error 

``
error: Referenced groupname does not exist / it is not defined with @apiDefine.
``

by adding extra asterisks to each `@apiDefine` block in `src/Services/ApiDocs.php`.

I have tested the fix on my project and my fork. Let me know if I need to do anything else, this is my first public pull request. Thanks :) 

EDIT:
Added another commit to branch. I realized I broke the StyleCI script. 
(I should probably figure out how to test that locally before creating another pull request)