### PR TITLE
Contact form fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /vendor
 /node_modules
 Homestead.yaml

--- a/app/Containers/Contact/Tasks/SendContactUsEmailTask.php
+++ b/app/Containers/Contact/Tasks/SendContactUsEmailTask.php
@@ -38,8 +38,10 @@ class SendContactUsEmailTask extends Task
      */
     public function run($fromEmail, $message, $subject = 'No Subject', $fromName = 'No Name')
     {
+        $this->email->to(env('MAIL_TO_SUPPORT_ADDRESS'));
         $this->email->setSubject($subject);
-        $result = $this->email->from($fromEmail, $fromName)->send([
+        $result = $this->email->send([
+            'email'   => $fromEmail,
             'name'    => $fromName,
             'content' => $message,
         ]);

--- a/app/Containers/Contact/UI/WEB/Views/EmailTemplates/contactUs.blade.php
+++ b/app/Containers/Contact/UI/WEB/Views/EmailTemplates/contactUs.blade.php
@@ -55,5 +55,8 @@
 <div>
     Message: {{$content}}
 </div>
+<div>
+    Email: {{$email}}
+</div>
 </body>
 </html>


### PR DESCRIPTION
Overwriting $email->from breaks smtp services such as AWS SES which needs a verified sender.
Email object was missing $email->to field, which triggers an Exception